### PR TITLE
fix ActiveRecord::StatementInvalid occured when schema load command executing

### DIFF
--- a/lib/i18n_konjac/acts_as_konjac.rb
+++ b/lib/i18n_konjac/acts_as_konjac.rb
@@ -6,6 +6,8 @@ module I18nKonjac
       def acts_as_konjac(options={})
         include I18nKonjac::ActsAsKonjac::LocalInstanceMethods
 
+        return unless ActiveRecord::Base.connection.table_exists? self.to_s.pluralize.underscore
+
         self.column_names.each do |column|
           define_method "#{column}_by_locale" do
             val = if self.attribute_present?("#{current_prefix}#{column}")


### PR DESCRIPTION
in mysql case has following error.

```
$ rake db:create db:schema:load --trace
** Invoke db:create (first_time)
** Invoke db:load_config (first_time)
** Execute db:load_config
** Execute db:create
** Invoke db:schema:load (first_time)
** Invoke environment (first_time)
** Execute environment
rake aborted!
ActiveRecord::StatementInvalid: Mysql2::Error: Table '*********' doesn't exist: SHOW FULL FIELDS FROM `***********`
```